### PR TITLE
Adds jekyll auto-generated sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,7 @@ paginate_path: "/thoughts/page:num"
 
 include: [".htaccess"]
 exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "test", "spec", "Gruntfile.js", "package.json", "node_modules", "_site", "assets/.sass-cache/"]
+
+# Gems
+gems:
+  - jekyll-sitemap

--- a/about.html
+++ b/about.html
@@ -3,18 +3,14 @@ layout: about
 title: About
 description: "Michelle Hertzfeld is a web designer with specialties in science communications, open data and user experience. Making content and communications kinder and clearer since 2001."
 permalink: /about/
-sitemap:
- priority: 0.5
- changefreq: yearly
- lastmod: 2013-10-15
 ---
 <div class="container" id="main" role="main" itemprop="mainContentOfPage" itemscope>
-    
+
 {% include contact.html %}
 
 <div class="sixteen columns alpha site_head" role="banner" itemscope itemtype="http://schema.org/WPHeader">
     <div class="five columns alpha">
-        <h1>About me</h1>  
+        <h1>About me</h1>
     </div>
     <div class="eight columns">
         <p>I've done lots of different things with my time, but designing for clarity and communication run through all of it. I'm especially into science communication.</p>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,13 @@ layout: home
 title: Home
 description: "Michelle Hertzfeld is a web designer with specialties in science communications, open data and user experience. Making content and communications kinder and clearer since 2001."
 permalink: /
-sitemap:
- priority: 1.0
- changefreq: weekly
- lastmod: 2013-10-20
 ---
 
 {% include contact.html %}
 
 <div class="sixteen columns alpha site_head" role="banner" itemscope itemtype="http://schema.org/WPHeader">
     <div class="five columns alpha">
-        <h1>Hi there!</h1>  
+        <h1>Hi there!</h1>
     </div>
     <div class="eight columns">
         <p>I'm Michelle. I design websites and user experiences. That means I specialize in clarity, structure and kindness. Read my thoughts here, or <a href="/work">see my latest work</a>. You can <a href="#home">say hello</a>, too!</p>
@@ -44,7 +40,7 @@ sitemap:
         {% endif %}
     </article>
 {% endfor %}
- 
+
 <!-- display four more posts smaller -->
     <article class="twelve columns alpha" itemscope itemtype="http://schema.org/BlogPosting">
         <h1 class="moar">more posts, yee haw!</h1>
@@ -66,4 +62,3 @@ sitemap:
             </div>
         {% endfor %}
     </article>
-    

--- a/thoughts.html
+++ b/thoughts.html
@@ -3,17 +3,13 @@ layout: home
 title: Thoughts
 description: "Michelle Hertzfeld is a web designer with specialties in science communications, open data and user experience. Making content and communications kinder and clearer since 2001."
 permalink: /thoughts/
-sitemap:
- priority: 0.5
- changefreq: weekly
- lastmod: 2013-10-20
 ---
 
 {% include contact.html %}
 
 <div class="sixteen columns alpha site_head" role="banner" itemscope itemtype="http://schema.org/WPHeader">
     <div class="five columns alpha">
-        <h1>Thoughts</h1>  
+        <h1>Thoughts</h1>
     </div>
     <div class="eight columns">
         <p>Here's a list of my latest posts. I think on lots of things, but here I write mostly on technology and design.</p>
@@ -23,7 +19,7 @@ sitemap:
         <div class="toggle top"><a href="#home">Contact</a></div>
     </div>
 </div>
- 
+
 <!-- display three latest posts with exerpts -->
     <article class="twelve columns alpha" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
         {% for post in site.categories.thoughts limit:10 %}

--- a/work.html
+++ b/work.html
@@ -3,10 +3,6 @@ layout: home
 title: Michelle Hertzfeld &#8211; Web and UX Designer &#8211; Work
 description: "Michelle Hertzfeld is a web designer with specialties in science communications, open data and user experience. Making content and communications kinder and clearer since 2001. This is her work."
 permalink: /work/
-sitemap:
- priority: 0.5
- changefreq: monthly
- lastmod: 2013-10-15
 ---
 
 <div id="contact" itemscope itemtype="http://schema.org/ContactPoint">
@@ -15,7 +11,7 @@ sitemap:
 
 <div class="sixteen columns alpha site_head">
     <div class="five columns alpha">
-        <h1>Work</h1>  
+        <h1>Work</h1>
     </div>
     <div class="eight columns">
         <p>I've done full design-and-code projects (CSS3, HTML5, jQuery) as well as structural user flow work. I really love working on science and data communication and maps. <a href="/about">It all makes sense.</a></p>
@@ -51,4 +47,3 @@ sitemap:
         </div>
     </article>
 </section>
-    


### PR DESCRIPTION
For #15. Adds `jekyll-sitemap` gem that should auto-generate a sitemap into `_site` provided that there is not already a `sitemap.xml` in root. This PR also removes old yml front matter where I attempted to create a sitemap with an outdated gem.
